### PR TITLE
Fix bug when initializing with non empty value

### DIFF
--- a/pyforms_web/controls/control_multipleselection.py
+++ b/pyforms_web/controls/control_multipleselection.py
@@ -57,8 +57,9 @@ class ControlMultipleSelection(ControlBase):
 		for v in value:
 			if len(v.strip())>0:
 				values.append(v)
-		properties.update({'value':values})
 		
-		ControlBase.deserialize(self, properties)
+		if values:
+			properties.update({'value':values})
+			ControlBase.deserialize(self, properties)
 		
 	


### PR DESCRIPTION
If the server sends value different than empty, the client would overrides with it's own value which is empty.